### PR TITLE
fix a flaky test

### DIFF
--- a/cacerts/pom.xml
+++ b/cacerts/pom.xml
@@ -14,7 +14,15 @@
 
   <modules>
     <module>full</module>
-<!--    <module>small</module>
-    <module>tiny</module> -->
+    <!--    <module>small</module>
+        <module>tiny</module> -->
   </modules>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jdom</groupId>
+      <artifactId>jdom2</artifactId>
+      <version>2.0.6</version> <!-- Use the latest version -->
+    </dependency>
+  </dependencies>
 </project>

--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -108,6 +108,12 @@
       <version>1.7</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jdom</groupId>
+      <artifactId>jdom2</artifactId>
+      <version>2.0.6</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -173,6 +179,14 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>8</source>
+          <target>8</target>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
### Description
Flaky tests are common occurrences in open-source projects, yielding inconsistent results—sometimes passing and sometimes failing—without code changes. NonDex is a tool for detecting and debugging wrong assumptions on under-determined Java APIs. I have resolved a flaky test issue using NonDex tool, specifically in the ConfigTest class located at `robovm/compiler/src/test/java/org/robovm/compiler/config/ConfigTest.java`. 

### Root cause
The root cause of the flakiness was related to that IOUtils.toString reads the content of an InputStream of XML file into a String, but it doesn't guarantee the order or sorting of elements within the content. The order of elements in the String will reflect the order in which the data was read from the InputStream. As a result, when that actual resulting string compares with expected string which is hardcoded, it causes intermittent failures. Furthermore, a persistent issue arises due to the incorrect display of file paths with their respective relative paths.

### Fix
This test has been resolved by recursive element sorting using JDOM2, which constructs an XML configuration and calculates the relative path for specific file entries in the XML. It then sorts the XML elements using a recursive sorting function sortElementRecursively. After sorting, it compares the sorted actual XML with the sorted expected XML to ensure they match. The primary change is to calculate the relative paths and update the expected XML accordingly. 

This fix is significant because it eliminates the uncertainty introduced by the order of elements in reading XML file, ensuring that the test consistently passes across different test runs. By doing so, we have improved the reliability and stability of our testing suite.

### How to test
Java: openjdk version "11.0.20.1"
Maven: Apache Maven 3.6.3
Add dependency to compiler/pom.xml
```xml
<dependency>
    <groupId>org.jdom</groupId>
    <artifactId>jdom2</artifactId>
    <version>2.0.6</version>
    <scope>test</scope>
</dependency>

```xml
<plugin>
    <groupId>org.apache.maven.plugins</groupId>
    <artifactId>maven-compiler-plugin</artifactId>
    <configuration>
        <source>8</source>
        <target>8</target>
    </configuration>
</plugin>

1. Compile the module
`mvn install -pl compiler -am -DskipTests`
2. Run regular tests
`mvn -pl compiler test -Dtest=org.robovm.compiler.config.ConfigTest#testWriteConsole`
3. Run tests with NonDex tool
`mvn -pl compiler edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.robovm.compiler.config.ConfigTest#testWriteConsole`
After fix, all tests pass